### PR TITLE
Fix a panic issue of loading an image from cache

### DIFF
--- a/images.go
+++ b/images.go
@@ -25,10 +25,11 @@ type Image struct {
 func (cv *Canvas) LoadImage(src interface{}) (*Image, error) {
 	if img, ok := src.(*Image); ok {
 		return img, nil
-	} else if img, ok := cv.images[src]; ok {
-		return img, nil
+	} else if _, ok := src.([]byte); !ok {
+		if img, ok := cv.images[src]; ok {
+			return img, nil
+		}
 	}
-
 	var srcImg image.Image
 	switch v := src.(type) {
 	case image.Image:
@@ -59,7 +60,9 @@ func (cv *Canvas) LoadImage(src interface{}) (*Image, error) {
 		return nil, err
 	}
 	cvimg := &Image{cv: cv, img: backendImg}
-	cv.images[src] = cvimg
+	if _, ok := src.([]byte); !ok {
+		cv.images[src] = cvimg
+	}
 	return cvimg, nil
 }
 


### PR DESCRIPTION
When calling LoadImage(src interface{}) with a byte array, there will be a panic:

panic: runtime error: hash of unhashable type []uint8

that is caused by visiting the map structure of the image cache using the content of the image (byte array) as the key. In order to avoid this issue, we added a condition before visiting the map.

See the changes. Thanks.